### PR TITLE
Migrate dashboard to esphome-device-builder and build with uv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
 	"workspaceFolder": "/config",
 	"containerEnv": {
 		"ESPHOME_VERBOSE": "true",
-		"ESPHOME_DASHBOARD_USE_PING": "1",
 		"TZ": "America/Los_Angeles"
 	},
 	"overrideCommand": true,

--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      # Pinned ESPHome version from the committed state file; drives the image
-      # tag and the ESPHOME_VERSION build-arg.
+      # Pinned ESPHome + device-builder versions from the committed state file;
+      # the esphome version drives the image tag, both become build-args.
       - name: Get pinned versions step
         id: esphome
         run: |

--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -49,9 +49,13 @@ jobs:
         run: |
           set -euo pipefail
           version="$(jq -r .version esphome-version.json)"
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "::error::Could not read .version from esphome-version.json"
+            exit 1
+          fi
           device_builder="$(jq -r .device_builder_version esphome-version.json)"
-          if [[ -z "$version" || "$version" == "null" || -z "$device_builder" || "$device_builder" == "null" ]]; then
-            echo "::error::Could not read versions from esphome-version.json"
+          if [[ -z "$device_builder" || "$device_builder" == "null" ]]; then
+            echo "::error::Could not read .device_builder_version from esphome-version.json"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       # Pinned ESPHome + device-builder versions from the committed state file;
-      # the esphome version drives the image tag, both become build-args.
+      # the ESPHome version drives the image tag, both become build-args.
       - name: Get pinned versions step
         id: esphome
         run: |

--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -44,16 +44,18 @@ jobs:
 
       # Pinned ESPHome version from the committed state file; drives the image
       # tag and the ESPHOME_VERSION build-arg.
-      - name: Get ESPHome version step
+      - name: Get pinned versions step
         id: esphome
         run: |
           set -euo pipefail
           version="$(jq -r .version esphome-version.json)"
-          if [[ -z "$version" || "$version" == "null" ]]; then
-            echo "::error::Could not read .version from esphome-version.json"
+          device_builder="$(jq -r .device_builder_version esphome-version.json)"
+          if [[ -z "$version" || "$version" == "null" || -z "$device_builder" || "$device_builder" == "null" ]]; then
+            echo "::error::Could not read versions from esphome-version.json"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "device_builder=$device_builder" >> "$GITHUB_OUTPUT"
 
       # QEMU emulates arm64; skip for amd64-only smoke builds.
       - name: Setup QEMU step
@@ -100,4 +102,5 @@ jobs:
           build-args: |
             LABEL_VERSION=${{ needs.get-version.outputs.SemVer2 }}
             ESPHOME_VERSION=${{ steps.esphome.outputs.version }}
+            DEVICE_BUILDER_VERSION=${{ steps.esphome.outputs.device_builder }}
 

--- a/.github/workflows/check-esphome-version.yml
+++ b/.github/workflows/check-esphome-version.yml
@@ -51,30 +51,42 @@ jobs:
           ref: ${{ matrix.branch }}
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Resolve latest ESPHome version and apply step
+      - name: Resolve latest upstream versions and apply step
         id: resolve
         run: |
           set -euo pipefail
-          latest="$(curl --silent --fail https://pypi.org/pypi/esphome/json | jq -r .info.version)"
-          if [[ -z "$latest" || "$latest" == "null" ]]; then
-            echo "::error::Could not resolve the latest esphome version from PyPI"
+          esphome_latest="$(curl --silent --fail https://pypi.org/pypi/esphome/json | jq -r .info.version)"
+          db_latest="$(curl --silent --fail https://pypi.org/pypi/esphome-device-builder/json | jq -r .info.version)"
+          if [[ -z "$esphome_latest" || "$esphome_latest" == "null" || -z "$db_latest" || "$db_latest" == "null" ]]; then
+            echo "::error::Could not resolve latest versions from PyPI"
             exit 1
           fi
-          current="$(jq -r .version esphome-version.json)"
-          echo "Branch=${{ matrix.branch }} Current=$current Latest=$latest"
-          if [[ "$latest" == "$current" ]]; then
+          esphome_current="$(jq -r .version esphome-version.json)"
+          db_current="$(jq -r .device_builder_version esphome-version.json)"
+          echo "Branch=${{ matrix.branch }} esphome=$esphome_current->$esphome_latest device-builder=$db_current->$db_latest"
+          if [[ "$esphome_latest" == "$esphome_current" && "$db_latest" == "$db_current" ]]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          if [[ "$esphome_latest" != "$esphome_current" && "$db_latest" != "$db_current" ]]; then
+            title="Bump ESPHome to $esphome_latest and device-builder to $db_latest"
+          elif [[ "$esphome_latest" != "$esphome_current" ]]; then
+            title="Bump ESPHome to $esphome_latest"
+          else
+            title="Bump device-builder to $db_latest"
+          fi
           tmp="$(mktemp)"
-          jq --arg v "$latest" '.version = $v' esphome-version.json > "$tmp"
+          jq --arg v "$esphome_latest" --arg d "$db_latest" '.version = $v | .device_builder_version = $d' esphome-version.json > "$tmp"
           # Keep CRLF (jq emits LF) so bumps don't churn line endings.
           sed -i 's/$/\r/' "$tmp"
           mv "$tmp" esphome-version.json
           {
             echo "changed=true"
-            echo "latest=$latest"
-            echo "current=$current"
+            echo "title=$title"
+            echo "esphome_latest=$esphome_latest"
+            echo "esphome_current=$esphome_current"
+            echo "db_latest=$db_latest"
+            echo "db_current=$db_current"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create version bump pull request step
@@ -88,13 +100,14 @@ jobs:
           branch: esphome-version-bump/${{ matrix.branch }}
           delete-branch: true
           sign-commits: true
-          title: Bump ESPHome to ${{ steps.resolve.outputs.latest }}
-          commit-message: Bump ESPHome to ${{ steps.resolve.outputs.latest }}
+          title: ${{ steps.resolve.outputs.title }}
+          commit-message: ${{ steps.resolve.outputs.title }}
           body: |
-            Bumps the pinned upstream ESPHome version in `esphome-version.json`.
+            Bumps the pinned upstream versions in `esphome-version.json`.
 
-            - ESPHome: `${{ steps.resolve.outputs.current }}` -> `${{ steps.resolve.outputs.latest }}`
-            - Release notes: https://github.com/esphome/esphome/releases/tag/${{ steps.resolve.outputs.latest }}
-            - PyPI: https://pypi.org/project/esphome/${{ steps.resolve.outputs.latest }}/
+            - ESPHome: `${{ steps.resolve.outputs.esphome_current }}` -> `${{ steps.resolve.outputs.esphome_latest }}`
+            - device-builder: `${{ steps.resolve.outputs.db_current }}` -> `${{ steps.resolve.outputs.db_latest }}`
+            - ESPHome PyPI: https://pypi.org/project/esphome/${{ steps.resolve.outputs.esphome_latest }}/
+            - device-builder PyPI: https://pypi.org/project/esphome-device-builder/${{ steps.resolve.outputs.db_latest }}/
 
-            The image tag and the `ESPHOME_VERSION` build-arg derive from this file. The new version ships on the next publish (weekly schedule, manual dispatch, or `PUBLISH_ON_MERGE`).
+            The esphome version drives the image tag; both are passed as build-args. The new versions ship on the next publish (weekly schedule, manual dispatch, or `PUBLISH_ON_MERGE`).

--- a/.github/workflows/check-esphome-version.yml
+++ b/.github/workflows/check-esphome-version.yml
@@ -58,7 +58,7 @@ jobs:
           esphome_latest="$(curl --silent --fail https://pypi.org/pypi/esphome/json | jq -r .info.version)"
           db_latest="$(curl --silent --fail https://pypi.org/pypi/esphome-device-builder/json | jq -r .info.version)"
           if [[ -z "$esphome_latest" || "$esphome_latest" == "null" ]]; then
-            echo "::error::Could not resolve the latest esphome version from PyPI"
+            echo "::error::Could not resolve the latest ESPHome version from PyPI"
             exit 1
           fi
           if [[ -z "$db_latest" || "$db_latest" == "null" ]]; then

--- a/.github/workflows/check-esphome-version.yml
+++ b/.github/workflows/check-esphome-version.yml
@@ -57,8 +57,12 @@ jobs:
           set -euo pipefail
           esphome_latest="$(curl --silent --fail https://pypi.org/pypi/esphome/json | jq -r .info.version)"
           db_latest="$(curl --silent --fail https://pypi.org/pypi/esphome-device-builder/json | jq -r .info.version)"
-          if [[ -z "$esphome_latest" || "$esphome_latest" == "null" || -z "$db_latest" || "$db_latest" == "null" ]]; then
-            echo "::error::Could not resolve latest versions from PyPI"
+          if [[ -z "$esphome_latest" || "$esphome_latest" == "null" ]]; then
+            echo "::error::Could not resolve the latest esphome version from PyPI"
+            exit 1
+          fi
+          if [[ -z "$db_latest" || "$db_latest" == "null" ]]; then
+            echo "::error::Could not resolve the latest esphome-device-builder version from PyPI"
             exit 1
           fi
           esphome_current="$(jq -r .version esphome-version.json)"
@@ -110,4 +114,4 @@ jobs:
             - ESPHome PyPI: https://pypi.org/project/esphome/${{ steps.resolve.outputs.esphome_latest }}/
             - device-builder PyPI: https://pypi.org/project/esphome-device-builder/${{ steps.resolve.outputs.db_latest }}/
 
-            The esphome version drives the image tag; both are passed as build-args. The new versions ship on the next publish (weekly schedule, manual dispatch, or `PUBLISH_ON_MERGE`).
+            The ESPHome version drives the image tag; both are passed as build-args. The new versions ship on the next publish (weekly schedule, manual dispatch, or `PUBLISH_ON_MERGE`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Clarify devcontainer setup steps in README
 
 - Use reference-style links for any URL referenced more than once or appearing in lists; alphabetize the reference definitions block.
 - Inline single-use relative links (e.g. `[CODESTYLE.md](./CODESTYLE.md)`) are fine.
-- One logical paragraph per line; no hard-wrap line-length limit.
+- One logical paragraph per line; no hard-wrap line-length limit. For an intentional hard line break within a block - stacked badges, status, or license lines - end the line with a trailing backslash (`\`); this explicit form is preferred over trailing whitespace for readability and is not treated as a paragraph split.
 - Headings follow the title-case-with-short-bind-words rule from the PR-title section.
 - **Write docs in the current state, not as a change from a prior one.** The reader has no memory of the previous behavior, so describe what *is*: "X does Y", never "X *now* does Y", "X *no longer* does Z", "changed/switched/restored to Y", or "X *still* does W". Before/after framing belongs in changelogs, commit messages, and PR descriptions - where the prior state is the point - not in `README.md` or other living docs.
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -50,7 +50,8 @@ RUN \
 # Builder
 WORKDIR /builder
 
-# Pinned upstream versions via build-args so the image is reproducible
+# Optional version pins via build-args; each pins its package independently
+# (empty = latest). The pipeline always passes both.
 ARG ESPHOME_VERSION=""
 ARG DEVICE_BUILDER_VERSION=""
 
@@ -59,17 +60,10 @@ ARG DEVICE_BUILDER_VERSION=""
 # esphome compiler (with display components) plus the device-builder dashboard.
 RUN pip install --no-cache-dir uv \
     && uv venv /opt/venv \
-    && if [ -n "$ESPHOME_VERSION" ] && [ -n "$DEVICE_BUILDER_VERSION" ]; then \
-        uv pip install --python /opt/venv/bin/python --no-cache \
-            setuptools \
-            "esphome[displays]==$ESPHOME_VERSION" \
-            "esphome-device-builder==$DEVICE_BUILDER_VERSION"; \
-    else \
-        uv pip install --python /opt/venv/bin/python --no-cache \
-            setuptools \
-            "esphome[displays]" \
-            "esphome-device-builder"; \
-    fi
+    && uv pip install --python /opt/venv/bin/python --no-cache \
+        setuptools \
+        "esphome[displays]${ESPHOME_VERSION:+==$ESPHOME_VERSION}" \
+        "esphome-device-builder${DEVICE_BUILDER_VERSION:+==$DEVICE_BUILDER_VERSION}"
 
 # Final
 FROM python:3.13-slim

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -50,16 +50,25 @@ RUN \
 # Builder
 WORKDIR /builder
 
-# Pin ESPHome version if provided via build-arg to ensure tag matches installed version
+# Pinned upstream versions via build-args so the image is reproducible
 ARG ESPHOME_VERSION=""
+ARG DEVICE_BUILDER_VERSION=""
 
-# Build wheel archives for setuptools and esphome with optional display components
-RUN if [ -n "$ESPHOME_VERSION" ]; then \
-        echo "Building wheel archives for setuptools and esphome[displays] version $ESPHOME_VERSION..."; \
-        pip wheel --no-cache-dir --progress-bar off --wheel-dir /builder/wheels setuptools "esphome[displays]==$ESPHOME_VERSION"; \
+# Build a self-contained virtual environment with uv. The slim final stage
+# copies it whole, so build tools never reach the final image. Installs the
+# esphome compiler (with display components) plus the device-builder dashboard.
+RUN pip install --no-cache-dir uv \
+    && uv venv /opt/venv \
+    && if [ -n "$ESPHOME_VERSION" ] && [ -n "$DEVICE_BUILDER_VERSION" ]; then \
+        uv pip install --python /opt/venv/bin/python --no-cache \
+            setuptools \
+            "esphome[displays]==$ESPHOME_VERSION" \
+            "esphome-device-builder==$DEVICE_BUILDER_VERSION"; \
     else \
-        echo "Building wheel archives for setuptools and latest esphome[displays]..."; \
-        pip wheel --no-cache-dir --progress-bar off --wheel-dir /builder/wheels setuptools "esphome[displays]"; \
+        uv pip install --python /opt/venv/bin/python --no-cache \
+            setuptools \
+            "esphome[displays]" \
+            "esphome-device-builder"; \
     fi
 
 # Final
@@ -68,10 +77,12 @@ FROM python:3.13-slim
 # Label
 ARG \
     LABEL_VERSION="1.0.0.0" \
-    ESPHOME_VERSION="1.0.0.0"
+    ESPHOME_VERSION="1.0.0.0" \
+    DEVICE_BUILDER_VERSION="1.0.0.0"
 LABEL name="ESPHome" \
     version=${LABEL_VERSION} \
     esphome_version=${ESPHOME_VERSION} \
+    device_builder_version=${DEVICE_BUILDER_VERSION} \
     description="ESPHome docker container that supports non-root operation" \
     maintainer="Pieter Viljoen <ptr727@users.noreply.github.com>"
 
@@ -114,17 +125,12 @@ ENV \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
 
-# Copy wheels from builder
-COPY --from=builder /builder/wheels /wheels
+# Copy the virtual environment from the builder and put it on PATH
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
-# TODO: Keep in sync with cache.sh
-
-# Install all packages from wheels archives
-RUN pip install --no-cache --no-index --find-links /wheels /wheels/* \
-    # Cleanup
-    && rm -rf /home \
-    && rm -rf /root \
-    && rm -rf /wheels \
+# Remove default home directories and prepare writable runtime directories
+RUN rm -rf /home /root \
     # Make sure there is a /tmp and /cache directory with full access for any user
     && mkdir -p /tmp /cache \
     && chmod 0777 /tmp /cache

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -57,7 +57,7 @@ ARG DEVICE_BUILDER_VERSION=""
 
 # Build a self-contained virtual environment with uv. The slim final stage
 # copies it whole, so build tools never reach the final image. Installs the
-# esphome compiler (with display components) plus the device-builder dashboard.
+# ESPHome compiler (with display components) plus the device-builder dashboard.
 RUN pip install --no-cache-dir uv \
     && uv venv /opt/venv \
     && uv pip install --python /opt/venv/bin/python --no-cache \

--- a/Docker/entrypoint/dashboard.sh
+++ b/Docker/entrypoint/dashboard.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-echo "Launching dashboard..."
-exec esphome dashboard /config
+echo "Launching device-builder dashboard..."
+exec esphome-device-builder /config

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
   - Migrated the dashboard to ESPHome's new [`esphome-device-builder`](https://github.com/esphome/device-builder) package ([#60](https://github.com/ptr727/ESPHome-NonRoot/issues/60)).
   - Switched the image build to a `uv` virtual environment copied into the slim final stage.
   - Pin and auto-track the `esphome-device-builder` version alongside `esphome`.
+  - Removed the no-op `ESPHOME_DASHBOARD_USE_PING` setting; device-builder always uses mDNS with a ping fallback.
 - Version 1.6:
   - Support `tmpfs` for optional `/tmp` volume, use `/tmp` instead of `/cache/tmp` for temp files.
   - Make `/cache` volume mount optional.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,9 @@
 ## Release History
 
 - Version 1.7:
-  - Migrated the dashboard to ESPHome's new [`esphome-device-builder`](https://github.com/esphome/device-builder) package ([#60](https://github.com/ptr727/ESPHome-NonRoot/issues/60)).
+  - Migrated the dashboard to ESPHome's new [`esphome-device-builder`][device-builder-link] package ([#60][issue-60-link]).
   - Switched the image build to a `uv` virtual environment copied into the slim final stage.
-  - Pin and auto-track the `esphome-device-builder` version alongside `esphome`.
+  - Pinned and auto-tracked the `esphome-device-builder` version alongside `esphome`.
   - Removed the no-op `ESPHOME_DASHBOARD_USE_PING` setting; device-builder always uses mDNS with a ping fallback.
 - Version 1.6:
   - Support `tmpfs` for optional `/tmp` volume, use `/tmp` instead of `/cache/tmp` for temp files.
@@ -14,13 +14,20 @@
 - Version 1.5:
   - Using Python 3.13 base image.
 - Version 1.4:
-  - Removed custom handling for `ESPHOME_VERBOSE` enabling `--verbose`, [PR](https://github.com/esphome/esphome/pull/6987) merged.
+  - Removed custom handling for `ESPHOME_VERBOSE` enabling `--verbose`, [PR][esphome-pr-6987-link] merged.
 - Version 1.3:
   - Added Dev Container [Workspace](./.devcontainer/devcontainer.code-workspace) that maps `config` and `cache` volumes.
 - Version 1.2:
   - Delete temp directory contents and prune PIO cached content on startup.
-  - Added [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) that can be used for [ESPHome](https://code.visualstudio.com/docs/python/debugging) or [PlatformIO](https://docs.platformio.org/en/latest/plus/debugging.html) debugging.
+  - Added [Dev Container][devcontainer-link] that can be used for [ESPHome][vscode-python-debug-link] or [PlatformIO][pio-debug-link] debugging.
 - Version 1.1:
   - Added daily actions job to trigger a build if the ESPHome version changed.
 - Version 1.0:
   - Initial public release.
+
+[devcontainer-link]: https://code.visualstudio.com/docs/devcontainers/containers
+[device-builder-link]: https://github.com/esphome/device-builder
+[esphome-pr-6987-link]: https://github.com/esphome/esphome/pull/6987
+[issue-60-link]: https://github.com/ptr727/ESPHome-NonRoot/issues/60
+[pio-debug-link]: https://docs.platformio.org/en/latest/plus/debugging.html
+[vscode-python-debug-link]: https://code.visualstudio.com/docs/python/debugging

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,25 @@
+# ESPHome-NonRoot
+
+## Release History
+
+- Version 1.7:
+  - Migrated the dashboard to ESPHome's new [`esphome-device-builder`](https://github.com/esphome/device-builder) package ([#60](https://github.com/ptr727/ESPHome-NonRoot/issues/60)).
+  - Switched the image build to a `uv` virtual environment copied into the slim final stage.
+  - Pin and auto-track the `esphome-device-builder` version alongside `esphome`.
+- Version 1.6:
+  - Support `tmpfs` for optional `/tmp` volume, use `/tmp` instead of `/cache/tmp` for temp files.
+  - Make `/cache` volume mount optional.
+  - Replace `locales-all` package with `locales` to reduce image size.
+- Version 1.5:
+  - Using Python 3.13 base image.
+- Version 1.4:
+  - Removed custom handling for `ESPHOME_VERBOSE` enabling `--verbose`, [PR](https://github.com/esphome/esphome/pull/6987) merged.
+- Version 1.3:
+  - Added Dev Container [Workspace](./.devcontainer/devcontainer.code-workspace) that maps `config` and `cache` volumes.
+- Version 1.2:
+  - Delete temp directory contents and prune PIO cached content on startup.
+  - Added [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) that can be used for [ESPHome](https://code.visualstudio.com/docs/python/debugging) or [PlatformIO](https://docs.platformio.org/en/latest/plus/debugging.html) debugging.
+- Version 1.1:
+  - Added daily actions job to trigger a build if the ESPHome version changed.
+- Version 1.0:
+  - Initial public release.

--- a/README.md
+++ b/README.md
@@ -22,23 +22,12 @@ Image is rebuilt weekly, or when a new ESPHome version is released, picking up t
 
 ## Release Notes
 
-- Version 1.6:
-  - Support `tmpfs` for optional `/tmp` volume, use `/tmp` instead of `/cache/tmp` for temp files.
-  - Make `/cache` volume mount optional.
-  - Replace `locales-all` package with `locales` to reduce image size.
-- Version 1.5:
-  - Using Python 3.13 base image.
-- Version 1.4:
-  - Removed custom handling for `ESPHOME_VERBOSE` enabling `--verbose`, [PR](https://github.com/esphome/esphome/pull/6987) merged.
-- Version 1.3:
-  - Added Dev Container [Workspace](./.devcontainer/devcontainer.code-workspace) that maps `config` and `cache` volumes.
-- Version 1.2:
-  - Delete temp directory contents and prune PIO cached content on startup.
-  - Added [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) that can be used for [ESPHome](https://code.visualstudio.com/docs/python/debugging) or [PlatformIO](https://docs.platformio.org/en/latest/plus/debugging.html) debugging.
-- Version 1.1:
-  - Added daily actions job to trigger a build if the ESPHome version changed.
-- Version 1.0:
-  - Initial public release.
+- Version 1.7:
+  - Migrated the dashboard to ESPHome's new [`esphome-device-builder`](https://github.com/esphome/device-builder) package ([#60](https://github.com/ptr727/ESPHome-NonRoot/issues/60)).
+  - Switched the image build to a `uv` virtual environment.
+  - Pin and auto-track the `esphome-device-builder` version alongside `esphome`.
+
+See [Release History](./HISTORY.md) for complete release notes and older versions.
 
 ## Usage
 
@@ -204,7 +193,7 @@ I have no name!@012d4b62d376:/config$
 
 - Use [Python](https://hub.docker.com/_/python) docker base image simplifying use for Python in a container environment.
 - Use a multi-stage build minimizing size and layer complexity of the final stage.
-- Build [`wheel`](https://pip.pypa.io/en/stable/cli/pip_wheel/) archives for the platform in the builder stage, and install the platform specific generated wheel packages in the final stage.
+- Use [`uv`](https://docs.astral.sh/uv/) to build a virtual environment in the builder stage, and copy the self-contained environment into the slim final stage.
 - Set appropriate PlatformIO and ESPHome environment variables to store projects in `/config` and dynamic and temporary content in `/cache` volumes.
 - Refer to [`Dockerfile`](./Docker/Dockerfile) for container details.
 - Refer to [`publish-release.yml`](./.github/workflows/publish-release.yml) (the publisher) and [`build-docker-task.yml`](./.github/workflows/build-docker-task.yml) (the image build) for pipeline details.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Image is rebuilt weekly, or when a new ESPHome version is released, picking up t
   - Migrated the dashboard to ESPHome's new [`esphome-device-builder`][device-builder-link] package ([#60][issue-60-link]).
   - Switched the image build to a `uv` virtual environment.
   - Pin and auto-track the `esphome-device-builder` version alongside `esphome`.
+  - Removed the no-op `ESPHOME_DASHBOARD_USE_PING` setting; device-builder always uses mDNS with a ping fallback.
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 
@@ -44,7 +45,6 @@ See [Release History](./HISTORY.md) for complete release notes and older version
     - `sudo chmod -R ug=rwx,o=rx /data/esphome`
 - `environment` :
   - `ESPHOME_VERBOSE` (Optional) : Enables [verbose][esphome-verbose-link] log output, e.g. `ESPHOME_VERBOSE=true`.
-  - `ESPHOME_DASHBOARD_USE_PING` (Optional) : Use [`ping` instead of `mDNS`][esphome-ping-link] to test if nodes are up, e.g. `ESPHOME_DASHBOARD_USE_PING=true`.
   - `TZ` (Optional) : Sets the [timezone][tz-link], e.g. `TZ=America/Los_Angeles`, default is `Etc/UTC`.
 
 ### Docker Compose Dashboard
@@ -59,7 +59,6 @@ services:
     environment:
       - TZ=America/Los_Angeles
       - ESPHOME_VERBOSE=true
-      - ESPHOME_DASHBOARD_USE_PING=true
     network_mode: bridge
     ports:
       - 6052:6052
@@ -222,7 +221,6 @@ Licensed under the [MIT License][license-link]\
 [esphome-globallib-link]: https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile#L67
 [esphome-installdeps-link]: https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile#L101
 [esphome-link]: https://esphome.io
-[esphome-ping-link]: https://github.com/esphome/issues/issues/641#issuecomment-534156628
 [esphome-pkginstall-link]: https://github.com/esphome/esphome/blob/2024.5.5/script/platformio_install_deps.py#L58
 [esphome-verbose-link]: https://esphome.io/guides/cli.html#cmdoption-v-verbose
 [github-link]: https://github.com/ptr727/ESPHome-NonRoot

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
 
 ## License
 
-Licensed under the [MIT License][license-link]  
+Licensed under the [MIT License][license-link]\
 ![GitHub License][license-shield]
 
 ## Build
 
-Code and Pipeline is on [GitHub][github-link].  
-Docker image is published on [Docker Hub][docker-link].  
+Code and Pipeline is on [GitHub][github-link].\
+Docker image is published on [Docker Hub][docker-link].\
 Image is rebuilt weekly, or when a new ESPHome version is released, picking up the latest ESPHome release and upstream container updates.
 
 ## Status
 
-[![Last Commit][last-commit-shield]][commit-link]  
-[![Workflow Status][workflow-status-shield]][actions-link]  
-[![Last Build][last-build-shield]][actions-link]  
+[![Last Commit][last-commit-shield]][commit-link]\
+[![Workflow Status][workflow-status-shield]][actions-link]\
+[![Last Build][last-build-shield]][actions-link]\
 [![Docker Latest][docker-latest-version-shield]][docker-link]
 
 ## Release Notes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Code and pipeline are on [GitHub][github-link].\
 Docker image is published on [Docker Hub][docker-link].\
-Image is rebuilt weekly, or when a new ESPHome version is released, picking up the latest ESPHome release and upstream container updates.
+Image is rebuilt on the weekly schedule and on demand, picking up the latest tracked ESPHome release and upstream container updates.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ I have no name!@012d4b62d376:/config$
   - [Issue #3929 : Not possible to run docker esphome/esphome container - problem with platformio][issue-3929-link].
   - [HA Community : Is there a way to run ESPhome in docker with custom UID and GID][ha-community-link].
   - Etc.
-- Issue analysis based on ESPHome `2024.5.5` (current version as of writing) [`Dockerfile`][esphome-dockerfile-link]:
+- Issue analysis based on ESPHome `2024.5.5` (the upstream version analyzed when this project was created) [`Dockerfile`][esphome-dockerfile-link]:
   - [`PLATFORMIO_GLOBALLIB_DIR=/piolibs`][esphome-globallib-link] sets the PlatformIO [`globallib_dir`][pio-globallib-env-link] option to `/piolibs`.
     - `/piolibs` is not mapped to an external volume.
     - `/piolibs` has default permissions and requires `root` write permissions at runtime.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 [ESPHome][esphome-link] docker container that supports non-root operation.
 
-## License
-
-Licensed under the [MIT License][license-link]\
-![GitHub License][license-shield]
-
 ## Build
 
 Code and Pipeline is on [GitHub][github-link].\
@@ -23,7 +18,7 @@ Image is rebuilt weekly, or when a new ESPHome version is released, picking up t
 ## Release Notes
 
 - Version 1.7:
-  - Migrated the dashboard to ESPHome's new [`esphome-device-builder`](https://github.com/esphome/device-builder) package ([#60](https://github.com/ptr727/ESPHome-NonRoot/issues/60)).
+  - Migrated the dashboard to ESPHome's new [`esphome-device-builder`][device-builder-link] package ([#60][issue-60-link]).
   - Switched the image build to a `uv` virtual environment.
   - Pin and auto-track the `esphome-device-builder` version alongside `esphome`.
 
@@ -48,9 +43,9 @@ See [Release History](./HISTORY.md) for complete release notes and older version
     - `sudo chown -R nonroot:users /data/esphome`
     - `sudo chmod -R ug=rwx,o=rx /data/esphome`
 - `environment` :
-  - `ESPHOME_VERBOSE` (Optional) : Enables [verbose](https://esphome.io/guides/cli.html#cmdoption-v-verbose) log output, e.g. `ESPHOME_VERBOSE=true`.
-  - `ESPHOME_DASHBOARD_USE_PING` (Optional) : Use [`ping` instead of `mDNS`](https://github.com/esphome/issues/issues/641#issuecomment-534156628) to test if nodes are up, e.g. `ESPHOME_DASHBOARD_USE_PING=true`.
-  - `TZ` (Optional) : Sets the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. `TZ=America/Los_Angeles`, default is `Etc/UTC`.
+  - `ESPHOME_VERBOSE` (Optional) : Enables [verbose][esphome-verbose-link] log output, e.g. `ESPHOME_VERBOSE=true`.
+  - `ESPHOME_DASHBOARD_USE_PING` (Optional) : Use [`ping` instead of `mDNS`][esphome-ping-link] to test if nodes are up, e.g. `ESPHOME_DASHBOARD_USE_PING=true`.
+  - `TZ` (Optional) : Sets the [timezone][tz-link], e.g. `TZ=America/Los_Angeles`, default is `Etc/UTC`.
 
 ### Docker Compose Dashboard
 
@@ -166,53 +161,92 @@ I have no name!@012d4b62d376:/config$
 
 - Running containers as non-privileged and as non-root is a docker best practice.
 - The official ESPHome [docker container][esphome-docker-link] does not support running as a non-root user.
-  - [Issue #3558 : Docker requires root](https://github.com/esphome/issues/issues/3558).
-  - [Issue #2752 : Docker image does not allow running rootless](https://github.com/esphome/issues/issues/2752).
-  - [Issue #3929 : Not possible to run docker esphome/esphome container - problem with platformio](https://github.com/esphome/issues/issues/3929).
-  - [HA Community : Is there a way to run ESPhome in docker with custom UID and GID](https://community.home-assistant.io/t/is-there-a-way-to-run-esphome-in-docker-with-custom-uid-and-gid/668256).
+  - [Issue #3558 : Docker requires root][issue-3558-link].
+  - [Issue #2752 : Docker image does not allow running rootless][issue-2752-link].
+  - [Issue #3929 : Not possible to run docker esphome/esphome container - problem with platformio][issue-3929-link].
+  - [HA Community : Is there a way to run ESPhome in docker with custom UID and GID][ha-community-link].
   - Etc.
-- Issue analysis based on ESPHome `2024.5.5` (current version as of writing) [`Dockerfile`](https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile):
-  - [`PLATFORMIO_GLOBALLIB_DIR=/piolibs`](https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile#L67) sets the PlatformIO [`globallib_dir`](https://docs.platformio.org/en/latest/envvars.html#envvar-PLATFORMIO_GLOBALLIB_DIR) option to `/piolibs`.
+- Issue analysis based on ESPHome `2024.5.5` (current version as of writing) [`Dockerfile`][esphome-dockerfile-link]:
+  - [`PLATFORMIO_GLOBALLIB_DIR=/piolibs`][esphome-globallib-link] sets the PlatformIO [`globallib_dir`][pio-globallib-env-link] option to `/piolibs`.
     - `/piolibs` is not mapped to an external volume.
     - `/piolibs` has default permissions and requires `root` write permissions at runtime.
-    - The [`globallib_dir`](https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/globallib_dir.html#projectconf-pio-globallib-dir) option has been deprecated.
+    - The [`globallib_dir`][pio-globallib-link] option has been deprecated.
       - `This option is DEPRECATED. We do not recommend using global libraries for new projects. Please use a declarative approach for the safety-critical embedded development and declare project dependencies using the lib_deps option.`
-  - [`platformio_install_deps.py`](https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile#L101) installs global libraries using [`pio pkg install -g`](https://github.com/esphome/esphome/blob/2024.5.5/script/platformio_install_deps.py#L58), the [`-g`](https://docs.platformio.org/en/stable/core/userguide/pkg/cmd_install.html#cmdoption-pio-pkg-install-g) option has been deprecated.
+  - [`platformio_install_deps.py`][esphome-installdeps-link] installs global libraries using [`pio pkg install -g`][esphome-pkginstall-link], the [`-g`][pio-pkg-g-link] option has been deprecated.
     - `We DO NOT recommend installing libraries in the global storage. Please use the lib_deps option and declare library dependencies per project.`
-  - The [presence](https://github.com/esphome/esphome/blob/2024.5.5/docker/docker_entrypoint.sh#L6) of a `/cache` directory changes `pio_cache_base` to `/cache/platformio`, the default is `/config/.esphome/platformio`
+  - The [presence][esphome-entrypoint-cache-link] of a `/cache` directory changes `pio_cache_base` to `/cache/platformio`, the default is `/config/.esphome/platformio`
     - `PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"`, `PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"`, and `PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"` is explicitly set as child directories of `pio_cache_base`.
-    - It is simpler to set `PLATFORMIO_CORE_DIR` PlatformIO [`core_dir`](https://docs.platformio.org/en/latest/envvars.html#envvar-PLATFORMIO_CORE_DIR) option, and not setting `PLATFORMIO_PLATFORMS_DIR` [`platforms_dir`](https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/platforms_dir.html#projectconf-pio-platforms-dir), `PLATFORMIO_PACKAGES_DIR` [`packages_dir`](https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/packages_dir.html#projectconf-pio-packages-dir), and `PLATFORMIO_CACHE_DIR` [`cache_dir`](https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/cache_dir.html#projectconf-pio-cache-dir) options, that are by default child directories of `core_dir`.
-  - The [presence](https://github.com/esphome/esphome/blob/2024.5.5/docker/docker_entrypoint.sh#L26) of a `/build` directory sets the `ESPHOME_BUILD_PATH` environment variable, that [sets](https://github.com/esphome/esphome/blob/2024.5.5/esphome/core/config.py#L204) the `CONF_BUILD_PATH` ESPHome [`build_path`](https://esphome.io/components/esphome.html) option, the default is `/config/.esphome/build`.
+    - It is simpler to set `PLATFORMIO_CORE_DIR` PlatformIO [`core_dir`][pio-coredir-env-link] option, and not setting `PLATFORMIO_PLATFORMS_DIR` [`platforms_dir`][pio-platformsdir-link], `PLATFORMIO_PACKAGES_DIR` [`packages_dir`][pio-packagesdir-link], and `PLATFORMIO_CACHE_DIR` [`cache_dir`][pio-cachedir-link] options, that are by default child directories of `core_dir`.
+  - The [presence][esphome-entrypoint-build-link] of a `/build` directory sets the `ESPHOME_BUILD_PATH` environment variable, that [sets][esphome-buildpath-sets-link] the `CONF_BUILD_PATH` ESPHome [`build_path`][esphome-buildpath-link] option, the default is `/config/.esphome/build`.
     - The directory presence detection could override an explicitly set `ESPHOME_BUILD_PATH` option.
-  - `ESPHOME_DATA_DIR` can be used to set the ESPHome [`data_dir`](https://github.com/esphome/esphome/blob/2024.5.5/esphome/core/__init__.py#L595) intermediate build output directory, the [default](https://github.com/esphome/esphome/blob/2024.5.5/esphome/core/__init__.py#L599) is `/config/.esphome`, or hardcoded to `/data` for the HA addon image.
-  - [`PLATFORMIO_CORE_DIR`](https://docs.platformio.org/en/latest/envvars.html#envvar-PLATFORMIO_CORE_DIR) PlatformIO [`core_dir`](https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/core_dir.html#projectconf-pio-core-dir) option is not set and defaults to `~/.platformio`.
-  - [`PIP_CACHE_DIR`](https://pip.pypa.io/en/stable/topics/caching/#pip-cache-dir) is not set and defaults to `~/.cache/pip`.
+  - `ESPHOME_DATA_DIR` can be used to set the ESPHome [`data_dir`][esphome-datadir-link] intermediate build output directory, the [default][esphome-datadir-default-link] is `/config/.esphome`, or hardcoded to `/data` for the HA addon image.
+  - [`PLATFORMIO_CORE_DIR`][pio-coredir-env-link] PlatformIO [`core_dir`][pio-coredir-link] option is not set and defaults to `~/.platformio`.
+  - [`PIP_CACHE_DIR`][pip-cache-link] is not set and defaults to `~/.cache/pip`.
   - `HOME` (`~`) is not set and defaults to e.g. `/home/[username]` or `/` or `/nonexistent` that either does not exists or the executing user does not have write permissions.
 
 ## Project Design
 
-- Use [Python](https://hub.docker.com/_/python) docker base image simplifying use for Python in a container environment.
+- Use [Python][python-link] docker base image simplifying use for Python in a container environment.
 - Use a multi-stage build minimizing size and layer complexity of the final stage.
-- Use [`uv`](https://docs.astral.sh/uv/) to build a virtual environment in the builder stage, and copy the self-contained environment into the slim final stage.
+- Use [`uv`][uv-link] to build a virtual environment in the builder stage, and copy the self-contained environment into the slim final stage.
 - Set appropriate PlatformIO and ESPHome environment variables to store projects in `/config` and dynamic and temporary content in `/cache` volumes.
 - Refer to [`Dockerfile`](./Docker/Dockerfile) for container details.
 - Refer to [`publish-release.yml`](./.github/workflows/publish-release.yml) (the publisher) and [`build-docker-task.yml`](./.github/workflows/build-docker-task.yml) (the image build) for pipeline details.
 
 ## Debugging
 
-The [included](./.devcontainer/devcontainer.json) [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) can be used for [ESPHome Python](https://code.visualstudio.com/docs/python/debugging) or [PlatformIO C++](https://docs.platformio.org/en/latest/plus/debugging.html) debugging in VSCode.
+The [included](./.devcontainer/devcontainer.json) [Dev Container][devcontainer-link] can be used for [ESPHome Python][vscode-python-debug-link] or [PlatformIO C++][pio-debug-link] debugging in VSCode.
 
-Detailed debug setup details are beyond the scope of this project, refer to my [ESPHome-Config](https://github.com/ptr727/ESPHome-Config) project for slightly more complete debugging setup instructions.
+Detailed debug setup details are beyond the scope of this project, refer to my [ESPHome-Config][esphome-config-link] project for slightly more complete debugging setup instructions.
+
+## License
+
+Licensed under the [MIT License][license-link]\
+![GitHub License][license-shield]
 
 [actions-link]: https://github.com/ptr727/ESPHome-NonRoot/actions
 [commit-link]: https://github.com/ptr727/ESPHome-NonRoot/commits/main
+[devcontainer-link]: https://code.visualstudio.com/docs/devcontainers/containers
+[device-builder-link]: https://github.com/esphome/device-builder
 [docker-latest-version-shield]: https://img.shields.io/docker/v/ptr727/esphome-nonroot/latest?label=Docker%20Latest&logo=docker
 [docker-link]: https://hub.docker.com/r/ptr727/esphome-nonroot
-[workflow-status-shield]: https://img.shields.io/github/actions/workflow/status/ptr727/ESPHome-NonRoot/publish-release.yml?event=schedule&logo=github&label=Workflow%20Status
+[esphome-buildpath-link]: https://esphome.io/components/esphome.html
+[esphome-buildpath-sets-link]: https://github.com/esphome/esphome/blob/2024.5.5/esphome/core/config.py#L204
+[esphome-config-link]: https://github.com/ptr727/ESPHome-Config
+[esphome-datadir-default-link]: https://github.com/esphome/esphome/blob/2024.5.5/esphome/core/__init__.py#L599
+[esphome-datadir-link]: https://github.com/esphome/esphome/blob/2024.5.5/esphome/core/__init__.py#L595
+[esphome-docker-link]: https://hub.docker.com/r/esphome/esphome
+[esphome-dockerfile-link]: https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile
+[esphome-entrypoint-build-link]: https://github.com/esphome/esphome/blob/2024.5.5/docker/docker_entrypoint.sh#L26
+[esphome-entrypoint-cache-link]: https://github.com/esphome/esphome/blob/2024.5.5/docker/docker_entrypoint.sh#L6
+[esphome-globallib-link]: https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile#L67
+[esphome-installdeps-link]: https://github.com/esphome/esphome/blob/2024.5.5/docker/Dockerfile#L101
+[esphome-link]: https://esphome.io
+[esphome-ping-link]: https://github.com/esphome/issues/issues/641#issuecomment-534156628
+[esphome-pkginstall-link]: https://github.com/esphome/esphome/blob/2024.5.5/script/platformio_install_deps.py#L58
+[esphome-verbose-link]: https://esphome.io/guides/cli.html#cmdoption-v-verbose
 [github-link]: https://github.com/ptr727/ESPHome-NonRoot
+[ha-community-link]: https://community.home-assistant.io/t/is-there-a-way-to-run-esphome-in-docker-with-custom-uid-and-gid/668256
+[issue-2752-link]: https://github.com/esphome/issues/issues/2752
+[issue-3558-link]: https://github.com/esphome/issues/issues/3558
+[issue-3929-link]: https://github.com/esphome/issues/issues/3929
+[issue-60-link]: https://github.com/ptr727/ESPHome-NonRoot/issues/60
 [last-build-shield]: https://byob.yarr.is/ptr727/ESPHome-NonRoot/lastbuild
 [last-commit-shield]: https://img.shields.io/github/last-commit/ptr727/ESPHome-NonRoot?logo=github&label=Last%20Commit
 [license-link]: ./LICENSE
 [license-shield]: https://img.shields.io/github/license/ptr727/ESPHome-NonRoot?label=License
-[esphome-link]: https://esphome.io
-[esphome-docker-link]: https://hub.docker.com/r/esphome/esphome
+[pio-cachedir-link]: https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/cache_dir.html#projectconf-pio-cache-dir
+[pio-coredir-env-link]: https://docs.platformio.org/en/latest/envvars.html#envvar-PLATFORMIO_CORE_DIR
+[pio-coredir-link]: https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/core_dir.html#projectconf-pio-core-dir
+[pio-debug-link]: https://docs.platformio.org/en/latest/plus/debugging.html
+[pio-globallib-env-link]: https://docs.platformio.org/en/latest/envvars.html#envvar-PLATFORMIO_GLOBALLIB_DIR
+[pio-globallib-link]: https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/globallib_dir.html#projectconf-pio-globallib-dir
+[pio-packagesdir-link]: https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/packages_dir.html#projectconf-pio-packages-dir
+[pio-pkg-g-link]: https://docs.platformio.org/en/stable/core/userguide/pkg/cmd_install.html#cmdoption-pio-pkg-install-g
+[pio-platformsdir-link]: https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/platforms_dir.html#projectconf-pio-platforms-dir
+[pip-cache-link]: https://pip.pypa.io/en/stable/topics/caching/#pip-cache-dir
+[python-link]: https://hub.docker.com/_/python
+[tz-link]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+[uv-link]: https://docs.astral.sh/uv/
+[vscode-python-debug-link]: https://code.visualstudio.com/docs/python/debugging
+[workflow-status-shield]: https://img.shields.io/github/actions/workflow/status/ptr727/ESPHome-NonRoot/publish-release.yml?event=schedule&logo=github&label=Workflow%20Status

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Build
 
-Code and Pipeline is on [GitHub][github-link].\
+Code and pipeline are on [GitHub][github-link].\
 Docker image is published on [Docker Hub][docker-link].\
 Image is rebuilt weekly, or when a new ESPHome version is released, picking up the latest ESPHome release and upstream container updates.
 
@@ -20,7 +20,7 @@ Image is rebuilt weekly, or when a new ESPHome version is released, picking up t
 - Version 1.7:
   - Migrated the dashboard to ESPHome's new [`esphome-device-builder`][device-builder-link] package ([#60][issue-60-link]).
   - Switched the image build to a `uv` virtual environment.
-  - Pin and auto-track the `esphome-device-builder` version alongside `esphome`.
+  - Pinned and auto-tracked the `esphome-device-builder` version alongside `esphome`.
   - Removed the no-op `ESPHOME_DASHBOARD_USE_PING` setting; device-builder always uses mDNS with a ping fallback.
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.

--- a/esphome-version.json
+++ b/esphome-version.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Pinned upstream versions, maintained by check-esphome-version.yml and read by build-docker-task.yml (the esphome version drives the image tag). Do not edit by hand; the tracker opens a bump PR when PyPI publishes newer versions.",
+  "$comment": "Pinned upstream versions, maintained by check-esphome-version.yml and read by build-docker-task.yml (the ESPHome version drives the image tag). Do not edit by hand; the tracker opens a bump PR when PyPI publishes newer versions.",
   "version": "2026.6.2",
   "device_builder_version": "1.0.12"
 }

--- a/esphome-version.json
+++ b/esphome-version.json
@@ -1,4 +1,5 @@
 {
-  "$comment": "Pinned upstream ESPHome version, maintained by check-esphome-version.yml and read by build-docker-task.yml (image tag + ESPHOME_VERSION build-arg). Do not edit by hand; the tracker opens a bump PR when PyPI publishes a newer version.",
-  "version": "2026.6.2"
+  "$comment": "Pinned upstream versions, maintained by check-esphome-version.yml and read by build-docker-task.yml (the esphome version drives the image tag). Do not edit by hand; the tracker opens a bump PR when PyPI publishes newer versions.",
+  "version": "2026.6.2",
+  "device_builder_version": "1.0.12"
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.6",
+  "version": "1.7",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Closes #60.

ESPHome split its dashboard into the separate [`esphome-device-builder`](https://github.com/esphome/device-builder) package. This installs it alongside the `esphome[displays]` compiler and launches `esphome-device-builder /config`.

## Changes

- **Dashboard**: `Docker/entrypoint/dashboard.sh` now runs `esphome-device-builder /config`. It binds `0.0.0.0:6052` and serves `/version`, so the port, healthcheck, and entrypoint passthrough model are unchanged. (Kept this project's `entrypoint`/passthrough model rather than upstream's `dashboard`-subcommand routing.)
- **Build → uv**: the builder stage builds a `uv` virtual environment (`uv venv /opt/venv` + `uv pip install esphome[displays]==$VER esphome-device-builder==$VER`) and the slim final stage copies it whole (`PATH=/opt/venv/bin`). Removes the wheel-archive shuffle, keeps build tools out of the final image, matches upstream's uv move.
- **Pin + auto-track both versions**: `esphome-version.json` gains `device_builder_version`; `check-esphome-version.yml` resolves/bumps both from PyPI (one rolling PR); `build-docker-task.yml` passes both as build-args; a `device_builder_version` image label is added. The image tag still tracks the esphome version.
- **Docs**: `version.json` → 1.7; new `HISTORY.md` (full history, template style); README release notes trimmed to the current release + link; Project Design updated to the uv approach.

## Verification (local, amd64)

Built the image and ran it as `--user 1001:100`:

- `/version` healthy in ~6s; device-builder boots fully; **ESPHome CLI sanity check OK (2026.6.2)** via `/opt/venv/bin/esphome`; binds `0.0.0.0:6052`.
- All device-builder state written **under `/config` as uid 1001** with no EACCES / no root-owned files: `.device-builder.json` (0600), `.device-builder-peer-link-key.bin` (0600), `secrets.yaml`, and the git version-history tree.
- Boots healthy **with and without** a `/cache` volume (tmpfs `/tmp`).
- Labels: `esphome_version=2026.6.2`, `device_builder_version=1.0.12`, `version=1.7.x`.

actionlint + markdownlint clean.

## CI note

This is the first real exercise of the new pipeline: the PR touches `Docker/**`, `esphome-version.json`, and `version.json`, so `test-pull-request.yml` runs the **amd64-only smoke build (no push)**. The build-only smoke can't catch runtime issues — covered by the local non-root run above. Full multi-arch publish stays deferred to `workflow_dispatch`/the weekly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)