### PR TITLE
Re-sync template carries from ProjectTemplate PR 167

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,31 +10,11 @@ This repository ships only a Docker image and has no language source tree, so th
 
 ## Commit Messages and Pull Request Titles
 
-Feature -> develop PRs squash-merge - the PR title becomes the single commit on develop. Develop -> main PRs merge-commit - main's history shows one merge commit per release with develop's tip as the second parent. Titles are descriptive and have no versioning effect - versioning is handled by [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) reading [version.json](../version.json) and git history, not by parsing commit messages.
+Summarized for VS Code's generators; the full rules, rationale, and examples are in [AGENTS.md "Pull Request Title and Commit Message Conventions"](../AGENTS.md#pull-request-title-and-commit-message-conventions).
 
-Branch protection enforces the merge method on both bases (develop allows only squash, main allows only merge). When running `gh pr merge` against either base, pick the matching flag (`--squash` for develop, `--merge` for main); a mismatch fails with "Merge method ... is not allowed on this repository". The merge-bot workflow (`.github/workflows/merge-bot-pull-request.yml`) does this dispatch automatically for Dependabot and codegen PRs via a `case` on `base.ref` - keep that pattern when adding new auto-merge jobs.
-
-### Format
-
-- Imperative subject summarizing the change, <= 72 characters, no trailing period. ("Add 24-hour PM2.5 average sensor", not "Added X" or "Adds X".)
-- Optional body, blank-line separated, explaining *why* the change is being made when that's non-obvious. The diff shows *what*.
-
-### Rules
-
-- Don't write `update stuff`, `wip`, or other vague titles. (Dependabot's default `Bump X from Y to Z` titles are fine - keep them.)
-- Don't add `Co-Authored-By:` lines unless the user explicitly asks.
-- Don't put release-bump magnitude in the title - no "minor", "patch", "release v0.2.0", etc. NBGV computes the next release version from `version.json` + git history. Dependency versions in dependency-bump titles are fine and expected.
-- Use US English spelling and match the existing heading style of the file you're editing: title case with lowercase short bind words (a, an, the, and, but, or, of, in, on, at, to, by, for, from); hyphenated compounds capitalize both parts unless the second is a short preposition (*Built-in*, *EPA-Corrected*, *24-Hour*).
-
-### Examples
-
-```text
-Add structured logging extensions to library
-Pin softprops/action-gh-release to commit SHA
-Drop net8.0 multi-targeting from console project
-Bump xunit.v3 from 3.2.2 to 3.3.0
-Clarify devcontainer setup steps in README
-```
+- Imperative subject, <= 72 characters, no trailing period; optional blank-line-separated body for the non-obvious *why*.
+- US English, title case with lowercase short bind words; no vague titles, no `Co-Authored-By:` unless asked, no release-bump magnitude (NBGV handles versioning). Dependabot's `Bump X from Y to Z` titles are fine.
+- develop PRs squash-merge (`gh pr merge --squash`), main PRs merge-commit (`--merge`); a mismatched flag is rejected by branch protection.
 
 ## GitHub Copilot Review Runbook
 
@@ -44,9 +24,9 @@ Use this section for provider-specific mechanics. The expected review loop *cont
 
 ### Triggering and Polling
 
-Auto-review on push is configured (via the branch ruleset's `copilot_code_review` rule with `review_on_push: true`) but fires inconsistently in practice - treat it as best-effort, not guaranteed. After every push, **re-request a review programmatically** via the GraphQL `requestReviews` mutation, passing the Copilot reviewer's bot node id in `botIds`. This now works reliably (it previously did not - a maintainer had to click "re-request review" in the UI; the agent can now drive the loop end-to-end without that hand-off).
+Auto-review on push is configured (via the branch ruleset's `copilot_code_review` rule with `review_on_push: true`) but fires inconsistently in practice - treat it as best-effort, not guaranteed. After every push, **re-request a review programmatically** via the GraphQL `requestReviews` mutation, passing the Copilot reviewer's bot node id in `botIds`. This drives the loop end-to-end without a UI hand-off.
 
-> **The reviewer login differs by API - this is intentional, not a typo.** In **GraphQL** (`gh api graphql` and `gh pr view --json reviews`, which is GraphQL-backed) the `Bot.login` is `copilot-pull-request-reviewer` - **no `[bot]` suffix**. In the **REST** API (`gh api repos/.../issues|pulls/...`) the same account's `user.login` is `copilot-pull-request-reviewer[bot]` - **with** the suffix. Each query below uses the correct form for its API; match the API, not a single spelling, when adapting them.
+> **The reviewer login differs by API.** In **GraphQL** (`gh api graphql` and `gh pr view --json reviews`, which is GraphQL-backed) the `Bot.login` is `copilot-pull-request-reviewer` - **no `[bot]` suffix**. In the **REST** API (`gh api repos/.../issues|pulls/...`) the same account's `user.login` is `copilot-pull-request-reviewer[bot]` - **with** the suffix. Each query below uses the correct form for its API; match the API, not a single spelling, when adapting them.
 
 ```sh
 # 1. PR node id + the Copilot reviewer's bot node id (read from any existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,14 @@ Clarify devcontainer setup steps in README
 - Headings follow the title-case-with-short-bind-words rule from the PR-title section.
 - **Write docs in the current state, not as a change from a prior one.** The reader has no memory of the previous behavior, so describe what *is*: "X does Y", never "X *now* does Y", "X *no longer* does Z", "changed/switched/restored to Y", or "X *still* does W". Before/after framing belongs in changelogs, commit messages, and PR descriptions - where the prior state is the point - not in `README.md` or other living docs.
 
+### Comments
+
+Code and workflow-YAML comments follow the same discipline as the prose above: concise, current-state, and within ~120 columns. Explain the non-obvious *why*, not the *what* the line already shows.
+
+- **No change-log narrative.** Describe what the code does now, not how it got there - no "previously", "now", "used to", "switched to" (the current-state rule from [Markdown](#markdown) applies to comments too).
+- **No rule citations.** State the behavior directly; don't cite this file or a ruleset from inside a comment.
+- **No cross-project references.** Don't name sibling downstream repos. The only cross-repo references this repo carries point at the upstream [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) parent, for re-syncing and drift-reporting.
+
 ### Character Set
 
 - **Write ASCII in all agent-authored text** - documentation, code, comments, commit messages, and PR descriptions. The agent does not introduce non-ASCII characters. Replace typographic Unicode with its ASCII equivalent on sight:
@@ -161,6 +169,7 @@ These conventions describe the target state. New and modified workflows must res
 - **Reusable workflows**: job-level `permissions:` are validated *before* the `if:` evaluates, so even a skipped job needs valid permissions declared. A `release` job with `permissions: contents: write` and `if: ${{ inputs.publish }}` will still cause `startup_failure` on a caller that doesn't grant `contents: write`. Either declare permissions at the call site, or omit the inner block and inherit.
 - **Allowlist `success` and `skipped` explicitly** when chaining jobs across optional dependencies - `!= 'failure'` lets `cancelled` through (timeout, runner failure, manual cancel). Use `(needs.X.result == 'success' || needs.X.result == 'skipped')`.
 - **Tag pinning on releases**: when using `softprops/action-gh-release` (or any tag-creating action), pass `target_commitish` explicitly - without it, GitHub's REST API defaults the new tag to the repository's default branch instead of the commit that built the artifact. Pin it to the **exact built commit's SHA** (the publisher uses NBGV's `GitCommitId` output), not `github.sha` (wrong branch in the publisher's branch matrix - a `develop` leg runs with `github.sha` = main's tip) and not a branch name (a moving ref that a mid-run commit could advance past the built tree).
+- **CI storage hygiene**: cache Docker layers to a registry tag (`type=registry`, as [`build-docker-task.yml`](./.github/workflows/build-docker-task.yml) does), never the GitHub Actions cache (`type=gha`); and set `retention-days: 1` on any *intermediate* `actions/upload-artifact` step - the 90-day default piles up against the 2 GB account storage quota. This repo currently uploads no intermediate artifacts (the Docker build pushes straight to the registry), so the retention half applies only if a future target adds an upload.
 
 ### Running the Linters Locally (Known-Working Invocations)
 

--- a/ESPHome-NonRoot.code-workspace
+++ b/ESPHome-NonRoot.code-workspace
@@ -81,11 +81,11 @@
 		"recommendations": [
 			"davidanson.vscode-markdownlint",
 			"eamodio.gitlens",
-			"gruntfuggly.todo-tree",
 			"ms-azuretools.vscode-docker",
 			"ms-vscode-remote.vscode-remote-extensionpack",
 			"redhat.vscode-yaml",
-			"streetsidesoftware.code-spell-checker"
+			"streetsidesoftware.code-spell-checker",
+			"fanaticpythoner.better-todo-tree"
 		]
 	}
 }


### PR DESCRIPTION
Re-syncs the template's verbatim-carry contract after upstream `ptr727/ProjectTemplate` PR #167 (tracked here as #64). Most of #64 was already in sync or N/A for this Docker-only repo; this is the small remaining delta.

## Changes

- **`.github/copilot-instructions.md`** - trim to the upstream-trimmed form: replace the duplicated full PR-title block with the 3-bullet summary that points at AGENTS.md, and drop two defensive-narrative spots in the Copilot runbook. Docker-only adaptations (no CODESTYLE pointer) preserved.
- **`AGENTS.md`** - add a `### Comments` house-rule (concise, current-state, no change-log narrative / rule citations / sibling-repo names) and a CI-storage-hygiene bullet (`type=registry` not `type=gha`; `retention-days: 1` on intermediate uploads, noting this repo uploads none).
- **`ESPHome-NonRoot.code-workspace`** - refresh extension recommendations (swap todo-tree extension), normalize indentation to tabs.

## Already in sync / N/A (no change)

`.gitattributes`, `.editorconfig` (`[*.cs]` already dropped), the docker-readme task + secrets, the markdown trailing-backslash and versioning rules; no `actions/upload-artifact` exists so `retention-days` is informational; carried-workflow comments were scanned and already comply.

## Upstream tracker stays bespoke

#64 also asked to migrate the version tracker to the canonical `check-upstream-version-task.yml`. That task serializes only a single bare-string version and cannot carry this repo's two keyed versions (`esphome` + `esphome-device-builder`) in the structured `esphome-version.json` the Docker build reads. `check-esphome-version.yml` stays; filed [ptr727/ProjectTemplate#168](https://github.com/ptr727/ProjectTemplate/issues/168) proposing structured multi-key state so it can converge later.

## Verification

- CRLF preserved on all edited files.
- `markdownlint-cli2` clean on both docs.

Closes #64.