### PR TITLE
Point devcontainer workspace at venv site-packages

### DIFF
--- a/.devcontainer/devcontainer.code-workspace
+++ b/.devcontainer/devcontainer.code-workspace
@@ -4,7 +4,7 @@
 			"path": "../."
 		},
 		{
-			"path": "../../../usr/local/lib/python3.13/site-packages"
+			"path": "../../../opt/venv/lib/python3.13/site-packages"
 		},
 		{
 			"path": "../../../config"


### PR DESCRIPTION
The uv migration installs ESPHome and device-builder into `/opt/venv` (the image sets `PATH=/opt/venv/bin`), so the devcontainer workspace folder pointing at `/usr/local/lib/python3.13/site-packages` no longer surfaces the installed packages for IntelliSense. Point it at the venv site-packages (`/opt/venv/lib/python3.13/site-packages`).

Surfaced by Copilot during the #70 develop->main promotion review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>