### PR TITLE
Re-sync release-publish dispatch guard from ProjectTemplate PR 184

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,7 +36,7 @@ indent_size = 2
 end_of_line = crlf
 indent_size = 2
 
-# Json and JsonC files
+# JSON and JSONC files
 [*.{json,jsonc}]
 end_of_line = crlf
 

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -68,6 +68,21 @@ jobs:
         with:
           ref: ${{ needs.get-version.outputs.GitCommitId }}
 
+      # Safety net: a public (main) release must never carry a prerelease identifier - any '-' in SemVer2 (e.g. the
+      # observed '-g<sha>' git-height suffix). Guards against NBGV mis-detecting the public ref (e.g. a dispatch on a
+      # non-default ref) from publishing a malformed non-prerelease release that GitHub would then mark "Latest".
+      # Root-cause-agnostic backstop to the dispatch-ref guard in publish-release.yml.
+      - name: Verify public release version step
+        if: ${{ inputs.branch == 'main' }}
+        env:
+          SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
+        run: |
+          set -euo pipefail
+          if [[ "$SEMVER2" == *-* ]]; then
+            echo "::error::Public (main) release version '$SEMVER2' carries a prerelease suffix; refusing to publish."
+            exit 1
+          fi
+
       # Collect any release-asset-<branch>-* artifacts. The Docker build pushes
       # directly and uploads none, so this matches nothing (which succeeds) and
       # the release carries just the tag + LICENSE/README.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,15 @@ jobs:
           PUBLISH_ON_MERGE: ${{ vars.PUBLISH_ON_MERGE }}
         run: |
           set -euo pipefail
+          # A schedule or dispatch builds BOTH branches in the matrix regardless of the triggering ref (a push builds
+          # only the pushed branch). Dispatching on a non-default ref makes the main leg mis-version (NBGV can't resolve
+          # the public main ref), publishing a malformed non-prerelease release that GitHub marks "Latest". Fail fast:
+          # dispatch only from the default branch.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" \
+                && "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]]; then
+            echo "::error::Dispatch publish-release from the default branch (${{ github.event.repository.default_branch }}); the matrix builds both branches. Re-dispatch on the default branch."
+            exit 1
+          fi
           case "${{ github.event_name }}" in
             push)
               branches='["${{ github.ref_name }}"]'


### PR DESCRIPTION
Re-converges this repo's verbatim-carry artifacts with upstream `ptr727/ProjectTemplate` **PR #184** ("Guard release publish against non-default-ref dispatch mis-versioning"). This is the only carry-affecting change since the last sync (#69 / upstream #174).

## Changes
- **`publish-release.yml`** — fail fast when `publish-release` is dispatched from a non-default ref. A schedule/dispatch builds *both* branches in the matrix, so a dispatch off a non-default ref made the `main` leg mis-version (NBGV can't resolve the public ref) and publish a malformed non-prerelease release GitHub then marks "Latest".
- **`build-release-task.yml`** — add a `Verify public release version step` backstop in the `github-release` job that refuses a `main` release whose SemVer2 carries a `-` prerelease suffix (root-cause-agnostic safety net).
- **`.editorconfig`** — carry the trivial "JSON and JSONC" comment-casing fix.

This directly guards the **publish gotcha** previously only documented in this repo's notes (a `develop` dispatch mis-versioning the `main` leg).

## Notes
- Incidentally normalizes two stray LF `uses:` lines in `build-release-task.yml` to CRLF per `.editorconfig` (`*.yml` = crlf). `get-version-task.yml` / `publish-docker-readme-task.yml` still carry stray LF lines — a separate minor EOL-hygiene cleanup, out of scope here.
- Upstream **#178** (CODESTYLE.md consolidation) and **#179** (skip artifact uploads on PR smoke builds) were evaluated and skipped as **N/A** for this Docker-only repo: no `CODESTYLE.md` / .NET / Python sources, and the Docker build pushes an image rather than uploading release-asset artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)