### PR TITLE
Re-sync merge-gate + prerelease guard from ProjectTemplate PR 190

### DIFF
--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -68,17 +68,17 @@ jobs:
         with:
           ref: ${{ needs.get-version.outputs.GitCommitId }}
 
-      # Safety net: a public (main) release must never carry a prerelease identifier - any '-' in SemVer2 (e.g. the
-      # observed '-g<sha>' git-height suffix). Guards against NBGV mis-detecting the public ref (e.g. a dispatch on a
-      # non-default ref) from publishing a malformed non-prerelease release that GitHub would then mark "Latest".
-      # Root-cause-agnostic backstop to the dispatch-ref guard in publish-release.yml.
+      # Backstop (main only): a public release must not carry a prerelease '-', guarding against NBGV mis-versioning the
+      # public ref (e.g. a dispatch on a non-default ref) into a malformed "Latest" release. Strip '+buildmetadata'
+      # first - a '-' there is legitimate; only a '-' in the core/prerelease segment marks a prerelease.
       - name: Verify public release version step
         if: ${{ inputs.branch == 'main' }}
         env:
           SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
         run: |
           set -euo pipefail
-          if [[ "$SEMVER2" == *-* ]]; then
+          CORE_AND_PRE="${SEMVER2%%+*}"   # drop +buildmetadata; a '-' here is the genuine prerelease separator
+          if [[ "$CORE_AND_PRE" == *-* ]]; then
             echo "::error::Public (main) release version '$SEMVER2' carries a prerelease suffix; refusing to publish."
             exit 1
           fi

--- a/.github/workflows/check-upstream-version-task.yml
+++ b/.github/workflows/check-upstream-version-task.yml
@@ -1,15 +1,9 @@
 name: Check upstream version task
 
-# Skeleton for a wrapper repo that tracks an upstream release. A resolver command
-# computes the upstream version(s) as a JSON object of name -> version, written to
-# a committed state file at the repo root (a build-input version source, beside
-# version.json), and opens a rolling, App-signed bump PR per branch that the
-# merge-bot auto-merges. The JSON object carries one key for the common
-# single-version case or N keys for a wrapper that pins several upstream
-# components (e.g. an image plus a companion tool); the build reads each component
-# by key. A merged bump ships on the next publish, not immediately. Call this from
-# a scheduled entry-point workflow; matrix only the branches that ship the version
-# (a CI-only version uses ["develop"]).
+# Skeleton for a wrapper repo tracking an upstream release: a resolver prints the upstream version(s) as a JSON object
+# of name -> version (one key, or N for a multi-component pin), written to a committed state file beside version.json,
+# and opens a rolling App-signed bump PR per branch that the merge-bot auto-merges. Call from a scheduled entry-point
+# workflow; matrix only the branches that ship the version (a CI-only version uses ["develop"]).
 
 on:
   workflow_call:
@@ -67,10 +61,8 @@ jobs:
           ref: ${{ matrix.branch }}
           token: ${{ steps.app-token.outputs.token }}
 
-      # The resolver prints a JSON object of name -> version. Normalize it (sorted keys, pretty
-      # print) so the committed state file and its diff are stable, then write it. Comparing the
-      # new object against the old state yields the changed keys that drive the bump PR's title
-      # and body (only the components that actually moved are named).
+      # Normalize the resolved JSON (sorted keys) so the committed file and its diff are stable; the old-vs-new key
+      # diff drives the PR title/body, naming only components that moved.
       - name: Resolve upstream version step
         id: resolve
         env:
@@ -79,10 +71,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Require a non-empty JSON object of single-line name -> version strings, so a malformed
-          # resolver (non-object, numeric/nested values, no keys, or a key/value carrying a CR/LF
-          # that would corrupt the single-line `title=`/`body` GITHUB_OUTPUT) fails fast here
-          # instead of committing state that downstream by-key build logic cannot consume.
+          # Require a non-empty JSON object of single-line name -> version strings; a CR/LF would corrupt the
+          # single-line GITHUB_OUTPUT, so reject it here instead of committing unconsumable state.
           raw="$(bash -c "$RESOLVER_COMMAND")"
           if ! new="$(printf '%s' "$raw" | jq -S '.' 2>/dev/null)" \
              || [ "$(printf '%s' "$new" | jq -r 'type == "object" and length > 0 and all(.[]; type == "string" and (test("[\r\n]") | not)) and (keys | all(test("[\r\n]") | not))')" != "true" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ Code and workflow-YAML comments follow the same discipline as the prose above: c
 - **No change-log narrative.** Describe what the code does now, not how it got there - no "previously", "now", "used to", "switched to" (the current-state rule from [Markdown](#markdown) applies to comments too).
 - **No rule citations.** State the behavior directly; don't cite this file or a ruleset from inside a comment.
 - **No cross-project references.** Don't name sibling downstream repos. The only cross-repo references this repo carries point at the upstream [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) parent, for re-syncing and drift-reporting.
+- **Keep it short.** One line is the default; a comment earns a second line only by carrying a constraint the code cannot. Most comments are one sentence. Don't restate *what* the code does - a well-named symbol already says it.
+- **Do not grow a comment across edits.** When you touch code near an existing comment, the comment must come out **same length or shorter** - never append "one more clause" of rationale. If a block comment has crept to multiple sentences of prose, cut it back to its single load-bearing point as part of your change. Verbosity creep is the regression to prevent: every iteration that adds a clause is a regression, not an improvement.
 
 ### Character Set
 
@@ -114,6 +116,19 @@ Code and workflow-YAML comments follow the same discipline as the prose above: c
 
 The repo runs a review loop on every PR: local agent iteration plus remote automated review (GitHub Copilot is the configured reviewer). Treat this as a contract regardless of which local agent authored the changes.
 
+### Merge Gate (read this first)
+
+**Do not merge - and do not enable auto-merge - unless ALL of these hold:**
+
+1. Required status checks are green (`mergeStateStatus: CLEAN`), **and**
+2. A Copilot review is confirmed on the **current head SHA** (not an earlier push), **and**
+3. **Every** Copilot finding on that head SHA is closed out - all review threads resolved, **and** any issue-level Copilot comments (which have no resolve action) triaged and replied to - so zero outstanding findings remain, **and**
+4. The maintainer has given **explicit** permission to merge.
+
+`mergeStateStatus: CLEAN` reflects **only** required statuses - it never reflects open bot review comments, so `CLEAN` alone is **never** sufficient to merge. A green/`CLEAN` PR with an unresolved Copilot finding fails this gate; treat it as "not mergeable" no matter what the merge-state field says. The agent never merges on its own (consistent with "default to staging"; merging is maintainer-authorized).
+
+**Merging is not releasing.** A merge to `main` does **not** publish - by default `PUBLISH_ON_MERGE` is off, so the push only smoke-runs the publisher's no-op job. Publishing happens solely on the weekly schedule or a manual `workflow_dispatch` (see [Release Model](#release-model)). Never describe a merge as cutting a release, and never trigger a publish without explicit maintainer instruction.
+
 ### Expected Review Loop
 
 1. Push changes to the PR branch.
@@ -124,7 +139,7 @@ The repo runs a review loop on every PR: local agent iteration plus remote autom
 6. Reply to each thread and resolve what was addressed.
 7. Re-run the loop after every fix push until no actionable findings remain.
 
-`mergeStateStatus: CLEAN` only checks required statuses; it does not block on bot review comments. Drive the loop to green - review confirmed on the latest head SHA and every actionable finding closed - and then **wait for the maintainer's explicit permission to merge**. The agent does not merge on its own (consistent with "default to staging"; merging is maintainer-authorized).
+Drive the loop to green - review confirmed on the latest head SHA and every actionable finding closed - then stop and apply the **Merge Gate** above: all four preconditions must hold, and `mergeStateStatus: CLEAN` alone never satisfies it.
 
 For provider-specific mechanics (how to request review, query review state, post replies, resolve threads), see the **GitHub Copilot Review Runbook** in [.github/copilot-instructions.md](./.github/copilot-instructions.md). This file owns the contract; that file owns the mechanics.
 


### PR DESCRIPTION
Re-syncs the verbatim-carry contract from upstream `ptr727/ProjectTemplate` **PR #190** (and follow-up commits), resolving the two issues filed from this repo while PR #77 was paused.

## Changes
- **`AGENTS.md`** — adds the explicit **Merge Gate (read this first)** checklist to PR Review Etiquette (required checks green **and** Copilot confirmed on current head **and** every finding closed **and** explicit maintainer OK), so `mergeStateStatus: CLEAN` can't be misread as merge-ready (**closes upstream #188**). Adds the **Merging is not releasing** note and the new comment-discipline rules.
- **`build-release-task.yml`** — strips `+buildmetadata` before the prerelease `-` check in the public-release backstop, so a hyphen in build metadata can't false-positive (**fixes upstream #189** — the finding Copilot raised on PR #77).
- **`check-upstream-version-task.yml`** — de-prose the carried skeleton comments.

## Not changed
The other de-prosed upstream workflows (`publish-release`, `build-datebadge`, `merge-bot`, `test-pull-request`) are already adapted to concise, Docker-specific comments here — nothing to port.

Once merged to `develop`, this propagates into the open promotion PR #77, resolving its outstanding Copilot finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)