### PR TITLE
Sync versioned branch rulesets as committed JSON

### DIFF
--- a/.github/rulesets/develop.json
+++ b/.github/rulesets/develop.json
@@ -1,0 +1,68 @@
+{
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/develop"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "name": "develop",
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "parameters": {
+        "allowed_merge_methods": [
+          "squash"
+        ],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true,
+        "required_reviewers": []
+      },
+      "type": "pull_request"
+    },
+    {
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Check pull request workflow status",
+            "integration_id": 15368
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      },
+      "type": "required_status_checks"
+    },
+    {
+      "parameters": {
+        "review_draft_pull_requests": true,
+        "review_on_push": true
+      },
+      "type": "copilot_code_review"
+    }
+  ],
+  "target": "branch"
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,65 @@
+{
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "name": "main",
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge"
+        ],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true,
+        "required_reviewers": []
+      },
+      "type": "pull_request"
+    },
+    {
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Check pull request workflow status",
+            "integration_id": 15368
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      },
+      "type": "required_status_checks"
+    },
+    {
+      "parameters": {
+        "review_draft_pull_requests": true,
+        "review_on_push": true
+      },
+      "type": "copilot_code_review"
+    }
+  ],
+  "target": "branch"
+}


### PR DESCRIPTION
## What

Adds the template's versioned branch rulesets as committed files:

- `.github/rulesets/develop.json`
- `.github/rulesets/main.json`

These carry the re-importable writable subset (`{name, target, enforcement, bypass_actors, conditions, rules}`) and port verbatim — `conditions` key on `refs/heads/{develop,main}`, `bypass_actors` uses the global Admin role `actor_id: 5`, the required check binds by name. `strict_required_status_checks_policy` is `false` on both branches.

## Why

Implements the downstream half of ptr727/ProjectTemplate#211. Branch rulesets were live GitHub config applied once at repo creation, so they sat outside the file-based re-sync loop: a corrected template ruleset never propagated here, and ruleset drift was invisible. Committing the canonical JSON makes the rulesets versioned, re-syncable, and drift-checkable.

This PR only lands the **files** (the source of truth). It does **not** modify this repo's live GitHub ruleset config — drift between these files and live config is reported to the maintainer separately and corrected via a full-payload PUT, never auto-applied. See the drift-check command and rationale in ptr727/ProjectTemplate `AGENTS.md` "Staying in Sync".

🤖 Generated with [Claude Code](https://claude.com/claude-code)