### PR TITLE
Reword diagram-intro sentence for clarity

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -216,7 +216,7 @@ required" signal that publishes the new upstream within ~a day, not just on the 
 ### Flow diagrams
 
 Four diagrams trace the architecture above: the pull-request gate, the self-publisher, the bot
-automation, and the upstream-version trigger chain. They are the same outcomes the section 4 contract specifies,
+automation, and the upstream-version trigger chain. They depict the same outcomes that the section 4 contract specifies,
 drawn from the workflow YAML; if a diagram and a guarantee disagree, one of them is a defect. Triggers
 are blue, gates yellow, durable/published outputs green, and stop/skip outcomes red.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -216,7 +216,7 @@ required" signal that publishes the new upstream within ~a day, not just on the 
 ### Flow diagrams
 
 Four diagrams trace the architecture above: the pull-request gate, the self-publisher, the bot
-automation, and the upstream-version trigger chain. They are the same outcomes section 4 contracts,
+automation, and the upstream-version trigger chain. They are the same outcomes the section 4 contract specifies,
 drawn from the workflow YAML; if a diagram and a guarantee disagree, one of them is a defect. Triggers
 are blue, gates yellow, durable/published outputs green, and stop/skip outcomes red.
 


### PR DESCRIPTION
Fleet-wide polish: reword the diagram-section intro sentence (Copilot flagged the original as garden-path grammar on several repos) to 'the same outcomes the section 4 contract specifies', applied identically across all seven repos for convergence.

markdownlint clean, EOL preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)