### PR TITLE
lint: add VS Code Lint tasks + :latest editorconfig checker

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Lint workflows step
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
 
-      - name: Check line endings step
-        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker@sha256:67b9e9b16a674e36f7c05919da789f03a01d343ca8423eb8797179399af07c00 # editorconfig-checker v3.4.0
+      - name: Check EditorConfig step
+        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker:latest

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+{
+    // VS Code tasks. Lint group - the local full doc-lint surface: the same tools and scope as the CI lint set
+    // (these run Docker at :latest, so versions can drift from CI's pinned actions). Run on demand. Every repo
+    // carries these. This repo has no compiled language, so there is no build or clean group.
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Lint: EditorConfig",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/check", "-w", "/check", "mstruebing/editorconfig-checker:latest" ],
+            "problemMatcher": [],
+            "presentation": { "showReuseMessage": false, "clear": false }
+        },
+        {
+            "label": "Lint: Workflows",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/repo", "-w", "/repo", "rhysd/actionlint:latest", "-color" ],
+            "problemMatcher": [],
+            "presentation": { "showReuseMessage": false, "clear": false }
+        },
+        {
+            "label": "Lint: Markdown",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "davidanson/markdownlint-cli2:latest", "**/*.md" ],
+            "problemMatcher": [],
+            "presentation": { "showReuseMessage": false, "clear": false }
+        },
+        {
+            "label": "Lint: Spelling",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "ghcr.io/streetsidesoftware/cspell:latest", "--no-progress", "README.md", "HISTORY.md" ],
+            "problemMatcher": [],
+            "presentation": { "showReuseMessage": false, "clear": false }
+        },
+        {
+            "label": "Lint: All",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "Lint: EditorConfig",
+                "Lint: Workflows",
+                "Lint: Markdown",
+                "Lint: Spelling"
+            ],
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
Brings the repo to the fleet per-surface lint architecture:

- **`.vscode/tasks.json`** (new) with the Lint group - *Lint: EditorConfig*, *Lint: Workflows*, *Lint: Markdown*, *Lint: Spelling*, and *Lint: All* - so the full doc-lint surface is runnable locally via Docker at `:latest`. No compiled language here, so there is no build/clean group and no language pre-commit hook.
- **editorconfig CI step** switched from a manually SHA-pinned digest to `:latest` and renamed *Check EditorConfig step* (Dependabot can't bump a `run:`-step digest, so `:latest` keeps it current; runners are ephemeral so each run pulls fresh).

Whole-repo editorconfig passes; tasks.json is CRLF, workflow stays LF.