### PR TITLE
Compile-test on any non-push event, not just on main and develop

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -48,12 +48,17 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          # A non-push event has no diff to reason about on any branch, so compile-test rather than guess.
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "compile-test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # On a long-lived branch the push itself is the change. On a feature branch diff the whole branch against
           # its merge-base instead, so the gate reflects the pull request and not merely its most recent push - a
           # later docs-only commit must not retire a compile test the branch's image change earned.
           if [[ "$REF_NAME" == "main" || "$REF_NAME" == "develop" ]]; then
-            # A new branch or non-push event has no usable before-commit (all-zeros or empty). Compile-test everything.
-            if [[ "$BEFORE" =~ ^0+$ || -z "$BEFORE" || "${{ github.event_name }}" != "push" ]]; then
+            # A new branch has no usable before-commit (all-zeros or empty). Compile-test everything.
+            if [[ "$BEFORE" =~ ^0+$ || -z "$BEFORE" ]]; then
               echo "compile-test=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi


### PR DESCRIPTION
## Why

The change-gate's fail-open for a non-push event was nested inside the `main`/`develop` arm:

```sh
if [[ "$REF_NAME" == "main" || "$REF_NAME" == "develop" ]]; then
  if [[ ... || "$EVENT_NAME" != "push" ]]; then   # only reachable on main/develop
```

So a `workflow_dispatch` on a **feature branch** skipped that check, fell through to the merge-base diff, and could resolve to `compile-test=false`. D1.1 states the gate is true "whenever the diff is unusable (new branch, force-push, dispatch)", so the code contradicted the contract.

Reproduced before fixing: a dispatch on a docs-only feature branch returned `compile-test=false`.

Found by Copilot on the promotion pull request. Worth noting why my own tests missed it: the suite had a case labelled "feature: empty BEFORE still uses merge-base" that returned `true`, but for a *content* reason - that branch had a `Docker/**` change - not because it failed open. The label read like dispatch coverage while asserting nothing of the kind.

## What

Short-circuit any non-push event to `compile-test=true` before the branch logic, so the rule is uniform rather than per-branch.

## Verification

Nine cases against real git history, with the dispatch cases now covering all three branch kinds:

| Case | Result |
| --- | --- |
| dispatch on docs-only feature branch | `true` (was `false`) |
| dispatch on `main` / on `develop` | `true` |
| feature: docs push, branch changed `Docker/**` | `true` |
| feature: branch touches only docs | `false` |
| `develop`: docs-only push | `false` |
| `develop`: `Docker/**` push | `true` |
| `develop`: new branch / unknown before-commit | `true` |

Push semantics are unchanged; only the non-push path moves.

Full lint gate green: actionlint, editorconfig-checker, markdownlint, cspell.

## Note

This blocks promotion #163, whose Copilot review surfaced it. Once this lands on `develop`, #163 picks it up automatically.
