### PR TITLE
Describe the compile-test input as change-gated, not off on push CI

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -13,8 +13,9 @@ on:
         required: false
         type: string
         default: ''
-      # Run the compile test. Off for push CI, which would pay ~5 minutes per push for a break that cannot reach
-      # users without a publish; the publisher turns it on so a broken image never gets pushed.
+      # Run the compile test. Defaults off, so a caller opts in: the publisher always does, and push CI does when
+      # its change-gate sees the image or its test inputs move. A push that cannot affect the image skips the
+      # ~5 minutes, and a broken image still never gets pushed.
       compile-test:
         required: false
         type: boolean

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -459,7 +459,7 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
   *Prevents a reusable-workflow or build break shipping untested, without charging every doc push ~5 minutes.*
 - **D1.2 Smoke builds the image.** Output: `smoke-build` builds the Docker image (amd64 only, seeded from the
   branch-scoped cache) to prove it still builds. There is no source-level unit test (nothing compiles here); the
-  artifact-level `compile-test` job exists but stays off on push CI (D11.1).
+  artifact-level `compile-test` job is change-gated on push CI (D1.1) and always on for a publish (D11.1).
 - **D1.3 Lint enforces the editor checks in CI.** Output: `validate-task`'s `lint` job runs `markdownlint-cli2`,
   `cspell` on the user-facing docs (README, HISTORY), and `actionlint` (which shellchecks every `run:`). Same
   checks the editor runs. There is no CSharpier / `dotnet format` step and no Python lint - nothing compiles


### PR DESCRIPTION
## Why

`validate-task.yml`'s `compile-test` input was documented as "Off for push CI". That was accurate when the input was added, and stopped being accurate when the change-gate landed - push CI now enables it whenever `Docker/**`, `.github/compile-test/**`, or `upstream-version.json` moves. A caller reading the input contract would be misled about when the job runs.

Raised by the Copilot review on promotion #163.

## What

Rewrites the input comment to describe the actual contract: defaults off, the publisher always opts in, push CI opts in when its change-gate fires.

Sweeping for the same claim elsewhere found a second instance the review did not flag - `WORKFLOW.md` D1.2 also said the job "stays off on push CI". Fixed both, since the defect is the class rather than the one line.

## Verification

- Re-swept for `off for push CI` / `off on push CI` after the edit: clean.
- Full lint gate green: actionlint, editorconfig-checker, markdownlint, cspell.

## Note

Blocks promotion #163, which picks this up automatically once merged.