### PR TITLE
Initialize the cache in the compile test the way a real run does

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -96,6 +96,9 @@ jobs:
 
           cat > "$workdir/config/compile.sh" <<'SH'
           set -euo pipefail
+          # Passing a command bypasses the image entrypoint, so initialize the cache the way a real run does
+          # rather than leaning on each tool to create its own tree under the world-writable mount.
+          /entrypoint/cache.sh
           for config in /config/*.yaml; do
             echo "::group::Compile $(basename "$config")"
             esphome config "$config" > /dev/null

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -288,7 +288,9 @@ It exists because a build-only smoke cannot see this class of break: ESPHome dow
 compile, and those binaries link against system libraries, so a missing runtime package surfaces only when a
 compile actually runs. Each fixture in `.github/compile-test/` is validated with `esphome config` and only then
 compiled, so a configuration break and a toolchain break give distinct signals, and the non-root uid asserts
-the property this image exists to provide.
+the property this image exists to provide. Passing a command bypasses the image entrypoint, so the run invokes
+`/entrypoint/cache.sh` first: the cache is initialized the way a real container start does, and that script -
+otherwise exercised by nothing - is covered too.
 
 The fixtures are chosen to span the *execution environments* a consumer hits, not to enumerate boards - each
 adds a dimension the others cannot reach:


### PR DESCRIPTION
## Why

The compile test runs `bash /config/compile.sh`, which takes the image entrypoint's `exec "$@"` branch, so `entrypoint/cache.sh` never runs and `/cache/{pio,build,data,pip,home}` are never created - including `HOME`.

Raised by the Copilot review on promotion #163.

## What the review predicted, and what actually happens

The review expected the run to fail on a fresh cache mount. It does not, and that was checked rather than assumed: with a genuinely empty `/cache`, `HOME=/cache/home` and `/cache/build` do not exist and `esphome config` still succeeds. Every compile run so far, local and in CI, started from an empty cache and passed. The tools create their own trees because the mount is world-writable.

So the predicted failure is not real. The underlying observation is, and the change is worth making for three other reasons:

1. **Fidelity.** The test should initialize the cache the way a container start does, rather than exercising a path no user takes.
2. **It removes an incidental dependency.** "It works because every tool happens to create its own directories" is true today and guaranteed by nothing.
3. **Coverage.** `entrypoint/cache.sh` is currently exercised by no test at all. This puts it under one.

## Verification

- `cache.sh` runs cleanly as uid 1000 and creates all five directories.
- The modified step was extracted from the workflow and run end to end: `Creating cache directories` / `Clearing temporary files` / `Pruning PIO cache` all execute, then the fixture compiles. Real exit code 0.
- Full lint gate green: actionlint, editorconfig-checker, markdownlint, cspell.

## Note

Blocks promotion #163, which picks this up once merged.